### PR TITLE
Supports Issue  #1 for the server

### DIFF
--- a/src/atari/graphics.c
+++ b/src/atari/graphics.c
@@ -115,9 +115,6 @@ void restoreGraphicsState(void)
 
 void setGraphicsMode(const byte mode)
 {
-    if(mode == settings.gfx_mode)
-        return;
-
     makeDisplayList(mode);
 
     OS.color1 = 14;         // Color maximum luminance
@@ -310,6 +307,37 @@ void clearFrameBuffer(void)
         case GRAPHICS_21:
             // Not sure what to do here yet.
         break;
+    }
+}
+
+char* graphics_mode_to_string(uint8_t mode)
+{
+    switch(mode)
+    {
+        case GRAPHICS_0:
+            return "ANTIC 0";
+        case GRAPHICS_8:
+            return "ANTIC 8";
+        case GRAPHICS_9:
+            return "ANTIC 9";
+        case GRAPHICS_10:
+            return "ANTIC 10";
+        case GRAPHICS_11:
+            return "ANTIC 11";
+        case GRAPHICS_8_CONSOLE:
+            return "ANTIC 8 and 0";
+        case GRAPHICS_9_CONSOLE:
+            return "ANTIC 9 and 0";
+        case GRAPHICS_10_CONSOLE:
+            return "ANTIC 10 and 0";
+        case GRAPHICS_11_CONSOLE:
+            return "ANTIC 11 and 0";
+        case GRAPHICS_20:
+            return "VBXE 320x240@256";
+        case GRAPHICS_21:
+            return "VBXE 640x480@16";
+        default:
+            return "Unknown";
     }
 }
 

--- a/src/atari/graphics.h
+++ b/src/atari/graphics.h
@@ -111,5 +111,6 @@ void setGraphicsMode(const byte mode);
 void clearFrameBuffer(void);
 void show_console(void);
 void hide_console(void);
+char* graphics_mode_to_string(uint8_t mode);
 
 #endif // GRAPHICS_H

--- a/src/atari/netimage.c
+++ b/src/atari/netimage.c
@@ -263,13 +263,22 @@ char stream_image(char* args[])
     else if((0 == strncmp(args[0], "search", 3) || (0 == strncmp(args[0], "gen", 3))) && (0 != args[1]))
     {
         // Build up the search string
-        strncpy(buff, args[0], 16);         
+        strncpy(buff, args[0], 16); // Add the command
+
+        // Generate has a special case.  It sends the model name along with the command.  Here we append.
+        if(0 == strncmp(args[0], "gen", 3))
+        {
+            strcat((char*)buff, " ");
+            strcat((char*)buff, settings.ai_model_name);
+        }
+
+        // Append the terms or phrase surround with quotes
         for(i = 1; i < NUM_TOKENS; ++i)
         {
             if(0x0 == args[i])
                 break;
 
-            if(i > 0)
+            if(i > 1)
                 strcat((char*)buff, " ");
             else
                 strcat((char*)buff, " \"");

--- a/src/atari/settings.h
+++ b/src/atari/settings.h
@@ -6,15 +6,18 @@
 
 //
 #define SERVER_URL_SIZE MAX_APPKEY_LEN
+#define AI_MODEL_NAME_SIZE 20
+
 #define SETTINGS_NONE 0
 #define SETTINGS_URL  1
 #define SETTINGS_GFX  2
+#define SETTINGS_AI_MODEL  3
 
 // A structure for holding the application runtime settings
 typedef struct {
-    char url[SERVER_URL_SIZE];
     byte gfx_mode;
-    byte blank[2];
+    char url[SERVER_URL_SIZE];
+    char ai_model_name[AI_MODEL_NAME_SIZE];
 } Settings;
 
 //unsigned char sio_openkey(AppKeyDataBlock* data, unsigned char open_mode, unsigned char key);
@@ -22,5 +25,7 @@ typedef struct {
 uint8_t get_settings(void);
 
 uint8_t put_settings(byte select);
+
+void print_settings(uint8_t mode, char* url, char* ai_model);
 
 #endif

--- a/src/atari/version.h
+++ b/src/atari/version.h
@@ -5,6 +5,6 @@
 
 #define MAJOR_VERSION 1
 #define MINOR_VERSION 5
-#define BUILD_VERSION 0
+#define BUILD_VERSION 1
 
 #endif // YAIL_VERSION_H

--- a/src/main.c
+++ b/src/main.c
@@ -16,12 +16,15 @@
 #include <stdbool.h>
 
 //
+extern Settings settings;
+extern ushort ORIG_VBII_SAVE;
+extern uint8_t SAVED_MODE;
+
+//
 char version[] = "YAIL (Yet Another Image Loader) v" TOSTR(MAJOR_VERSION) "." TOSTR(MINOR_VERSION) "." TOSTR(BUILD_VERSION);
 
 byte buff[256]; // A block of memory to be used by all.
 bool done = false;
-extern Settings settings;
-extern ushort ORIG_VBII_SAVE;
 
 void help()
 {
@@ -93,6 +96,8 @@ int main(int argc, char* argv[])
                 if(ch == CH_ENTER)
                     ch = 0x00;
                 
+                SAVED_MODE = settings.gfx_mode;
+
                 show_console();
                 start_console(ch);   // send the character just entered so the console will start with it shown
             }


### PR DESCRIPTION
Complies with the new generate command which expects the next token to be the model to use, then followed by the prompt.
Saves the model to a new FN app key d00d103.
Fixed up the help screen to support.
Added a settings view. Simply type set with no arguments.